### PR TITLE
fix escaped strings in merged referenced dictionaries

### DIFF
--- a/reclass/datatypes/parameters.py
+++ b/reclass/datatypes/parameters.py
@@ -40,7 +40,7 @@ class Parameters(object):
     functionality and does not try to be a really mapping object.
     '''
 
-    def __init__(self, mapping, settings, uri):
+    def __init__(self, mapping, settings, uri, merge_initialise = True):
         self._settings = settings
         self._base = {}
         self._uri = uri
@@ -51,10 +51,13 @@ class Parameters(object):
         self._needs_all_envs = False
         self._keep_overrides = False
         if mapping is not None:
-            # we initialise by merging
-            self._keep_overrides = True
-            self.merge(mapping)
-            self._keep_overrides = False
+            if merge_initialise:
+                # we initialise by merging
+                self._keep_overrides = True
+                self.merge(mapping)
+                self._keep_overrides = False
+            else:
+                self._base = mapping
 
     #delimiter = property(lambda self: self._delimiter)
 

--- a/reclass/datatypes/parameters.py
+++ b/reclass/datatypes/parameters.py
@@ -57,7 +57,7 @@ class Parameters(object):
                 self.merge(mapping)
                 self._keep_overrides = False
             else:
-                self._base = mapping
+                self._base = copy.deepcopy(mapping)
 
     #delimiter = property(lambda self: self._delimiter)
 

--- a/reclass/datatypes/parameters.py
+++ b/reclass/datatypes/parameters.py
@@ -181,7 +181,7 @@ class Parameters(object):
         else:
             return self._update_value(cur, new)
 
-    def merge(self, other):
+    def merge(self, other, wrap=True):
         """Merge function (public edition).
 
         Call _merge_recurse on self with either another Parameter object or a
@@ -197,9 +197,15 @@ class Parameters(object):
 
         self._unrendered = None
         if isinstance(other, dict):
-            wrapped = self._wrap_dict(other, DictPath(self._settings.delimiter))
+            if wrap:
+                wrapped = self._wrap_dict(other, DictPath(self._settings.delimiter))
+            else:
+                wrapped = copy.deepcopy(other)
         elif isinstance(other, self.__class__):
-            wrapped = self._wrap_dict(other._base, DictPath(self._settings.delimiter))
+            if wrap:
+                wrapped = self._wrap_dict(other._base, DictPath(self._settings.delimiter))
+            else:
+                wrapped = copy.deepcopy(other._base)
         else:
             raise TypeError('Cannot merge %s objects into %s' % (type(other),
                             self.__class__.__name__))

--- a/reclass/datatypes/tests/test_parameters.py
+++ b/reclass/datatypes/tests/test_parameters.py
@@ -572,5 +572,23 @@ class TestParametersNoMock(unittest.TestCase):
         self.assertEqual(error.exception.message, "-> \n   Cannot resolve ${beta}, at alpha")
         self.assertEqual(std_err.text(), err1)
 
+    def test_escaped_string_in_ref_dict_1(self):
+        # test with escaped string in first dict to be merged
+        p1 = Parameters({'a': { 'one': '${a_ref}' }, 'b': { 'two': '\${not_a_ref}' }, 'c': '${b}', 'a_ref': 123}, SETTINGS, '')
+        p2 = Parameters({'c': '${a}'}, SETTINGS, '')
+        r = { 'a': { 'one': 123 }, 'b': { 'two': '${not_a_ref}' }, 'c': { 'one': 123, 'two': '${not_a_ref}' }, 'a_ref': 123}
+        p1.merge(p2)
+        p1.interpolate()
+        self.assertEqual(p1.as_dict(), r)
+
+    def test_escaped_string_in_ref_dict_2(self):
+        # test with escaped string in second dict to be merged
+        p1 = Parameters({'a': { 'one': '${a_ref}' }, 'b': { 'two': '\${not_a_ref}' }, 'c': '${a}', 'a_ref': 123}, SETTINGS, '')
+        p2 = Parameters({'c': '${b}'}, SETTINGS, '')
+        r = { 'a': { 'one': 123 }, 'b': { 'two': '${not_a_ref}' }, 'c': { 'one': 123, 'two': '${not_a_ref}' }, 'a_ref': 123}
+        p1.merge(p2)
+        p1.interpolate()
+        self.assertEqual(p1.as_dict(), r)
+
 if __name__ == '__main__':
     unittest.main()

--- a/reclass/values/valuelist.py
+++ b/reclass/values/valuelist.py
@@ -107,8 +107,8 @@ class ValueList(object):
                 deepCopied = False
             else:
                 if isinstance(output, dict) and isinstance(new, dict):
-                    p1 = Parameters(output, self._settings, None)
-                    p2 = Parameters(new, self._settings, None)
+                    p1 = Parameters(output, self._settings, None, merge_initialise = False)
+                    p2 = Parameters(new, self._settings, None, merge_initialise = False)
                     p1.merge(p2)
                     output = p1.as_dict()
                     continue

--- a/reclass/values/valuelist.py
+++ b/reclass/values/valuelist.py
@@ -109,7 +109,7 @@ class ValueList(object):
                 if isinstance(output, dict) and isinstance(new, dict):
                     p1 = Parameters(output, self._settings, None, merge_initialise = False)
                     p2 = Parameters(new, self._settings, None, merge_initialise = False)
-                    p1.merge(p2)
+                    p1.merge(p2, wrap=False)
                     output = p1.as_dict()
                     continue
                 elif isinstance(output, list) and isinstance(new, list):


### PR DESCRIPTION
Fixes a fairly obscure bug that if an escaped string in a dictionary is referenced and subsequently merged with another dict then the escape of the string is lost and it's treated as a real reference or inventory query. An example:

```yaml
#node1
classes:
  - first
  - second

# first
parameters:
  a:
    one: ${a_ref}
  b:
    two: \${not_a_ref}
  c: ${a}
  a_ref: 123

# second
parameters:
  c: ${b}
```
Will result in a missing reference error for ${not_a_ref}.

This is fixed by initialising the parameters objects for the merge using a deep copy and when setting up the merge deep copying the second dict instead of wrapping the key values of the dictionary in Value objects.

This works for me both in testing and on my live system, but given this introduces changes in the merge step and it's taken me a few tries to get this right, I would like to see this tested on a few other sets of reclass data to ensure as well as possible that there's no other subtle problem introduced by the changes.