### PR TITLE
Removed install prefix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,3 @@
 # will need to generate wheels for each Python version that you support.
 universal=0
 
-[install]
-prefix: /usr


### PR DESCRIPTION
The install prefix should not be set as it's user specific. In our case, it breaks the reclass installation when referenced from git like:
```
git+https://github.com/salt-formulas/reclass.git@<tag>#egg=reclass
```