### PR TITLE
Fix failure of parameter overwrites in some cases

### DIFF
--- a/reclass/datatypes/parameters.py
+++ b/reclass/datatypes/parameters.py
@@ -153,6 +153,9 @@ class Parameters(object):
         ret = cur
         for (key, newvalue) in iteritems(new):
             if key.startswith(self._settings.dict_key_override_prefix) and not self._keep_overrides:
+                if not isinstance(newvalue, Value):
+                    newvalue = Value(newvalue, self._settings, self._uri)
+                newvalue.overwrite = True
                 ret[key.lstrip(self._settings.dict_key_override_prefix)] = newvalue
             else:
                 ret[key] = self._merge_recurse(ret.get(key), newvalue, path.new_subpath(key))
@@ -176,7 +179,6 @@ class Parameters(object):
             dict: a merged dictionary
 
         """
-
 
         if cur is None:
             return new

--- a/reclass/datatypes/tests/test_parameters.py
+++ b/reclass/datatypes/tests/test_parameters.py
@@ -643,5 +643,18 @@ class TestParametersNoMock(unittest.TestCase):
         p1.interpolate()
         self.assertEqual(p1.as_dict(), r)
 
+    def test_complex_overwrites_1(self):
+        # find a better name for this test
+        p1 = Parameters({ 'test': { 'dict': { 'a': '${values:one}', 'b': '${values:two}' } },
+                          'values': { 'one': 1, 'two': 2, 'three': { 'x': 'X', 'y': 'Y' } } }, SETTINGS, '')
+        p2 = Parameters({ 'test': { 'dict': { 'c': '${values:two}' } } }, SETTINGS, '')
+        p3 = Parameters({ 'test': { 'dict': { '~b': '${values:three}' } } }, SETTINGS, '')
+        r = {'test': {'dict': {'a': 1, 'b': {'x': 'X', 'y': 'Y'}, 'c': 2}}, 'values': {'one': 1, 'three': {'x': 'X', 'y': 'Y'}, 'two': 2} }
+        p2.merge(p3)
+        p1.merge(p2)
+        p1.interpolate()
+        self.assertEqual(p1.as_dict(), r)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/reclass/values/value.py
+++ b/reclass/values/value.py
@@ -17,6 +17,7 @@ class Value(object):
     def __init__(self, value, settings, uri):
         self._settings = settings
         self._uri = uri
+        self._overwrite = False
         if isinstance(value, str):
             try:
                 self._item = self._parser.parse(value, self._settings)
@@ -29,6 +30,14 @@ class Value(object):
             self._item = DictItem(value, self._settings)
         else:
             self._item = ScaItem(value, self._settings)
+
+    @property
+    def overwrite(self):
+        return self._overwrite
+
+    @overwrite.setter
+    def overwrite(self, overwrite):
+        self._overwrite = overwrite
 
     def uri(self):
         return self._uri

--- a/reclass/values/valuelist.py
+++ b/reclass/values/valuelist.py
@@ -104,7 +104,7 @@ class ValueList(object):
                 else:
                     raise e
 
-            if output is None:
+            if output is None or value.overwrite:
                 output = new
                 deepCopied = False
             else:
@@ -124,6 +124,7 @@ class ValueList(object):
                     raise TypeError('Cannot merge %s over %s' % (repr(self._values[n]), repr(self._values[n-1])))
                 else:
                     output = new
+                    deepCopied = False
 
         if isinstance(output, (dict, list)) and last_error is not None:
             raise last_error


### PR DESCRIPTION
Some overwrites would fail raising a type mismatch error. For example:

```yaml
# nodes/node1.yml 
classes:
  - first
  - second

# classes/first.yml 
parameters:
  _system_:
    repos:
      a: ${_values_:one}
      b: ${_values_:two}
  _values_:
    one: 1
    two: 2
    three:
      x: X
      y: Y

# classes/second.yml 
classes:
  - third
parameters:
  _system_:
    repos:
      ~b: ${_values_:three}

# classes/third.yml 
parameters:
  _system_:
    repos:
      c: ${_values_:two}
```

Would fail with: TypeError: Cannot merge Value(RefItem([ScaItem('_values_:three')])) over Value(RefItem([ScaItem('_values_:two')]))

The fix adds an overwrite flag to the Value class. During merging the value which will overwrite the key is wrapped in a Value object and the overwrite flag set. Then during the ValueList render method the flag is checked to force an overwrite rather than raise an error.

The original behaviour of replacing the current value of the key with the new value, rather than merging, is retained. It isn't strictly required any more as the ValueList render method would handle the overwrite after merging but there's no need to keep the old value.
