### PR TITLE
Fix nested dict merges where None appear on one side

### DIFF
--- a/reclass/datatypes/parameters.py
+++ b/reclass/datatypes/parameters.py
@@ -122,13 +122,17 @@ class Parameters(object):
         else:
             values = ValueList(Value(cur, self._settings, self._uri), self._settings)
 
-        if isinstance(new, Value):
+
+        value_list = isinstance(new, ValueList) or isinstance(cur, ValueList)
+
+        if not value_list and (new.contents() is None or new.contents() == cur.contents()):
+            return cur
+        elif isinstance(new, Value):
             values.append(new)
         elif isinstance(new, ValueList):
             values.extend(new)
         else:
             values.append(Value(new, self._settings, self._uri))
-
         return values
 
     def _merge_dict(self, cur, new, path):
@@ -178,7 +182,7 @@ class Parameters(object):
         """
 
 
-        if cur is None:
+        if cur is None or str(cur) == 'None':
             return new
         elif isinstance(new, dict) and isinstance(cur, dict):
             return self._merge_dict(cur, new, path)


### PR DESCRIPTION
to be evaluated
possibly does similar or nearly the same as #31 

@AndrewPickford pls review, especially to #1 extent. Thanks


The before behavior:

```
#Dict merges with None and { '_class': {'second': Value(ScaItem('second') resulted in ValueLists like :
{ '_class': {'second': ValueList([Value(ScaItem('second')), Value(ScaItem(None))])}}
```

