### PR TITLE
YAML: Use C bindings if available

### DIFF
--- a/reclass/output/yaml_outputter.py
+++ b/reclass/output/yaml_outputter.py
@@ -9,15 +9,17 @@
 from reclass.output import OutputterBase
 import yaml
 
+_SafeDumper = yaml.CSafeDumper if yaml.__with_libyaml__ else yaml.SafeDumper
+
 class Outputter(OutputterBase):
 
     def dump(self, data, pretty_print=False, no_refs=False):
         if (no_refs):
             return yaml.dump(data, default_flow_style=not pretty_print, Dumper=ExplicitDumper)
         else:
-            return yaml.dump(data, default_flow_style=not pretty_print)
+            return yaml.dump(data, default_flow_style=not pretty_print, Dumper=_SafeDumper)
 
-class ExplicitDumper(yaml.SafeDumper):
+class ExplicitDumper(_SafeDumper):
     """
     A dumper that will never emit aliases.
     """

--- a/reclass/storage/yamldata.py
+++ b/reclass/storage/yamldata.py
@@ -11,6 +11,8 @@ import yaml
 import os
 from reclass.errors import NotFoundError
 
+_SafeLoader = yaml.CSafeLoader if yaml.__with_libyaml__ else yaml.SafeLoader
+
 class YamlData(object):
 
     @classmethod
@@ -23,7 +25,7 @@ class YamlData(object):
             raise NotFoundError('Cannot open: %s' % abs_path)
         y = cls('yaml_fs://{0}'.format(abs_path))
         with open(abs_path) as fp:
-            data = yaml.safe_load(fp)
+            data = yaml.load(fp, Loader=_SafeLoader)
             if data is not None:
                 y._data = data
         return y
@@ -32,7 +34,7 @@ class YamlData(object):
     def from_string(cls, string, uri):
         ''' Initialise yaml data from a string '''
         y = cls(uri)
-        data = yaml.safe_load(string)
+        data = yaml.load(string, Loader=_SafeLoader)
         if data is not None:
             y._data = data
         return y


### PR DESCRIPTION
Forwarded pull request which I merged into my fork a few months ago which I'd mostly forgotten about. From the original pull request (https://github.com/AndrewPickford/reclass/pull/3) on my fork:

> C bindings offer a considerable speed increase, so use them when
> available (i.e. if libyaml is installed).
> While at it, explicitly use safe dump for reference-enabled YAML.
> Fixes: https://jira.opnfv.org/browse/FUEL-346
> Above link has some numbers, on AArch64 this changes translates to ~50% time decrease for a large reclass inventory.

Other than dealing with a small merge conflict in  reclass/storage/yamldata.py due to 3048be2f70ccf773e35dabe83eda98059377cf5b it's the same patch. I don't see any reason not to merge it in here as well.
