### PR TITLE
Bump version 1.5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
 # To test example models with kitchen:
 - export PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
 - kitchen list
-- if [ "$PYTHON_VERSION" = "2.7" ]; then kitchen test; fi
+- kitchen test
 
 # NOTE: travis stage builds, below saved for future reference
 #jobs:

--- a/README.rst
+++ b/README.rst
@@ -24,3 +24,26 @@ Documentation
 
 Documentation covering the original version is in the doc directory.
 See the README-extensions.rst file for documentation on the extentions.
+
+
+
+Reclass related projects/tools
+==============================
+
+Queries:
+
+* yg, yaml grep with 'jq' syntax - https://gist.github.com/epcim/f1c5b748fa7c942de50677aef04f29f8, (https://asciinema.org/a/84173)
+* reclass-graph - https://github.com/tomkukral/reclass-graph
+  
+Introspection, manupulation:
+
+* reclass-tools, for manipulating reclass models - https://github.com/dis-xcom/reclass_tools
+
+YAML merge tools:
+
+* spruce, general purpose YAML & JSON merging tool - https://github.com/geofffranks/spruce
+
+Other:
+
+* saltclass, new pillar/master_tops module for salt with the behaviour of reclass - https://github.com/saltstack/salt/pull/42349
+

--- a/reclass.py
+++ b/reclass.py
@@ -6,6 +6,10 @@
 # Copyright © 2007–13 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import reclass.cli
 reclass.cli.main()

--- a/reclass/__init__.py
+++ b/reclass/__init__.py
@@ -6,11 +6,14 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
-from reclass.output import OutputLoader
-from reclass.storage.loader import StorageBackendLoader
-from reclass.storage.memcache_proxy import MemcacheProxy
-
+from .output import OutputLoader
+from .storage.loader import StorageBackendLoader
+from .storage.memcache_proxy import MemcacheProxy
 
 def get_storage(storage_type, nodes_uri, classes_uri, **kwargs):
     storage_class = StorageBackendLoader(storage_type).load()

--- a/reclass/adapters/__init__.py
+++ b/reclass/adapters/__init__.py
@@ -5,4 +5,8 @@
 #
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
-#
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals

--- a/reclass/adapters/ansible.py
+++ b/reclass/adapters/ansible.py
@@ -14,6 +14,11 @@
 # The ansible adapter has received little testing and may not work at all now.
 
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import os, sys, posix, optparse
 
 from six import iteritems
@@ -89,9 +94,9 @@ def cli():
 
             data = groups
 
-        print output(data, options.output, options.pretty_print, options.no_refs)
+        print(output(data, options.output, options.pretty_print, options.no_refs))
 
-    except ReclassException, e:
+    except ReclassException as e:
         e.exit_with_message(sys.stderr)
 
     sys.exit(posix.EX_OK)

--- a/reclass/adapters/salt.py
+++ b/reclass/adapters/salt.py
@@ -6,6 +6,10 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import os, sys, posix
 
@@ -122,9 +126,9 @@ def cli():
                        class_mappings=class_mappings,
                        **defaults)
 
-        print output(data, options.output, options.pretty_print, options.no_refs)
+        print(output(data, options.output, options.pretty_print, options.no_refs))
 
-    except ReclassException, e:
+    except ReclassException as e:
         e.exit_with_message(sys.stderr)
 
     sys.exit(posix.EX_OK)

--- a/reclass/cli.py
+++ b/reclass/cli.py
@@ -6,6 +6,10 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import sys, os, posix
 

--- a/reclass/config.py
+++ b/reclass/config.py
@@ -6,13 +6,17 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import yaml, os, optparse, posix, sys
 
-import errors
-from defaults import *
-from constants import MODE_NODEINFO, MODE_INVENTORY
-from reclass import get_path_mangler
+from . import errors, get_path_mangler
+from .defaults import *
+from .constants import MODE_NODEINFO, MODE_INVENTORY
+
 
 def make_db_options_group(parser, defaults={}):
     ret = optparse.OptionGroup(parser, 'Database options',
@@ -171,7 +175,7 @@ def get_options(name, version, description,
 
 
 def vvv(msg):
-    #print >>sys.stderr, msg
+    #print(msg, file=sys.stderr)
     pass
 
 
@@ -180,8 +184,8 @@ def find_and_read_configfile(filename=CONFIG_FILE_NAME,
     for d in dirs:
         f = os.path.join(d, filename)
         if os.access(f, os.R_OK):
-            vvv('Using config file: {0}'.format(f))
-            return yaml.safe_load(file(f))
+            vvv('Using config file: {0}'.format(str(f)))
+            return yaml.safe_load(open(f))
         elif os.path.isfile(f):
             raise PermissionsError('cannot read %s' % f)
     return {}

--- a/reclass/constants.py
+++ b/reclass/constants.py
@@ -6,6 +6,11 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 
 class _Constant(object):
 

--- a/reclass/core.py
+++ b/reclass/core.py
@@ -6,6 +6,10 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import copy
 import time
@@ -24,10 +28,6 @@ from reclass.datatypes import Entity, Classes, Parameters, Exports
 from reclass.errors import MappingFormatError, ClassNameResolveError, ClassNotFound, InvQueryClassNameResolveError, InvQueryClassNotFound, InvQueryError, InterpolationError, ResolveError
 from reclass.values.parser import Parser
 
-try:
-    basestring
-except NameError:
-    basestring = str
 
 class Core(object):
 
@@ -130,7 +130,7 @@ class Core(object):
                         if self._cnf_r.match(klass):
                             if self._settings.ignore_class_notfound_warning:
                                 # TODO, add logging handler
-                                print >>sys.stderr, "[WARNING] Reclass class not found: '%s'. Skipped!" % klass
+                                print("[WARNING] Reclass class not found: '%s'. Skipped!" % klass, file=sys.stderr)
                             continue
                     e.nodename = nodename
                     e.uri = entity.uri
@@ -151,7 +151,7 @@ class Core(object):
 
     def _get_automatic_parameters(self, nodename, environment):
         if self._settings.automatic_parameters:
-            return Parameters({ '_reclass_': { 'name': { 'full': nodename, 'short': str.split(nodename, '.')[0] },
+            return Parameters({ '_reclass_': { 'name': { 'full': nodename, 'short': nodename.split('.')[0] },
                                                'environment': environment } }, self._settings, '__auto__')
         else:
             return Parameters({}, self._settings, '')

--- a/reclass/datatypes/__init__.py
+++ b/reclass/datatypes/__init__.py
@@ -6,6 +6,11 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from .applications import Applications
 from .classes import Classes
 from .entity import Entity

--- a/reclass/datatypes/applications.py
+++ b/reclass/datatypes/applications.py
@@ -6,6 +6,11 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 
 from .classes import Classes
 
@@ -61,4 +66,4 @@ class Applications(Classes):
         contents = self._items + \
                 ['%s%s' % (self._negation_prefix, i) for i in self._negations]
         return "%s(%r, %r)" % (self.__class__.__name__, contents,
-                               self._negation_prefix)
+                               str(self._negation_prefix))

--- a/reclass/datatypes/classes.py
+++ b/reclass/datatypes/classes.py
@@ -6,6 +6,15 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+#try:
+#    from types import StringTypes
+#except ImportError:
+#    StringTypes = (str, )
 
 import six
 import os
@@ -52,6 +61,7 @@ class Classes(object):
             self.append_if_new(i)
 
     def _assert_is_string(self, item):
+        #if not isinstance(item, StringTypes):
         if not isinstance(item, six.string_types):
             raise TypeError('%s instances can only contain strings, '\
                             'not %s' % (self.__class__.__name__, type(item)))

--- a/reclass/datatypes/entity.py
+++ b/reclass/datatypes/entity.py
@@ -6,6 +6,11 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from .classes import Classes
 from .applications import Applications
 from .exports import Exports

--- a/reclass/datatypes/exports.py
+++ b/reclass/datatypes/exports.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass (http://github.com/madduck/reclass)
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import copy
 

--- a/reclass/datatypes/parameters.py
+++ b/reclass/datatypes/parameters.py
@@ -7,6 +7,16 @@
 # Released under the terms of the Artistic Licence 2.0
 #
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+#try:
+#    from types import StringTypes
+#except ImportError:
+#    StringTypes = (str, )
+
 import copy
 import sys
 import types

--- a/reclass/datatypes/tests/__init__.py
+++ b/reclass/datatypes/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals

--- a/reclass/datatypes/tests/test_applications.py
+++ b/reclass/datatypes/tests/test_applications.py
@@ -6,8 +6,14 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from reclass.datatypes import Applications, Classes
 import unittest
+
 try:
     import unittest.mock as mock
 except ImportError:

--- a/reclass/datatypes/tests/test_classes.py
+++ b/reclass/datatypes/tests/test_classes.py
@@ -6,9 +6,15 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from reclass.datatypes import Classes
 from reclass.datatypes.classes import INVALID_CHARACTERS_FOR_CLASSNAMES
 import unittest
+
 try:
     import unittest.mock as mock
 except ImportError:

--- a/reclass/datatypes/tests/test_entity.py
+++ b/reclass/datatypes/tests/test_entity.py
@@ -6,11 +6,16 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from reclass.settings import Settings
 from reclass.datatypes import Entity, Classes, Parameters, Applications, Exports
 from reclass.errors import ResolveError
 import unittest
+
 try:
     import unittest.mock as mock
 except ImportError:

--- a/reclass/datatypes/tests/test_exports.py
+++ b/reclass/datatypes/tests/test_exports.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass (http://github.com/madduck/reclass)
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from reclass.settings import Settings
 from reclass.datatypes import Exports, Parameters

--- a/reclass/datatypes/tests/test_parameters.py
+++ b/reclass/datatypes/tests/test_parameters.py
@@ -6,6 +6,10 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import copy
 
@@ -15,6 +19,7 @@ from reclass.settings import Settings
 from reclass.datatypes import Parameters
 from reclass.errors import InfiniteRecursionError, InterpolationError, ResolveError, ResolveErrorList
 import unittest
+
 try:
     import unittest.mock as mock
 except ImportError:

--- a/reclass/defaults.py
+++ b/reclass/defaults.py
@@ -6,6 +6,11 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import os, sys
 from .version import RECLASS_NAME
 

--- a/reclass/errors.py
+++ b/reclass/errors.py
@@ -6,6 +6,10 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import posix, sys
 import traceback
@@ -39,14 +43,12 @@ class ReclassException(Exception):
     def exit_with_message(self, out=sys.stderr):
         if self._full_traceback:
             t, v, tb = sys.exc_info()
-            print >>out, 'Full Traceback:'
+            print('Full Traceback', file=out)
             for l in traceback.format_tb(tb):
-                print >>out, l,
-            print >>out
+                print(l, file=out)
         if self._traceback:
-            print >>out, self._traceback
-        print >>out, self.message
-        print >>out
+            print(self._traceback, file=out)
+        print(self.message, file=out)
         sys.exit(self.rc)
 
 

--- a/reclass/output/__init__.py
+++ b/reclass/output/__init__.py
@@ -6,7 +6,10 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 class OutputterBase(object):
 
@@ -14,7 +17,7 @@ class OutputterBase(object):
         pass
 
     def dump(self, data, pretty_print=False):
-        raise NotImplementedError('dump() method not implemented.')
+        raise NotImplementedError("dump() method not implemented.")
 
 
 class OutputLoader(object):
@@ -24,7 +27,7 @@ class OutputLoader(object):
         try:
             self._module = __import__(self._name, globals(), locals(), self._name)
         except ImportError:
-            raise NotImplementedError
+            raise NotImplementedError()
 
     def load(self, attr='Outputter'):
         klass = getattr(self._module, attr, None)

--- a/reclass/output/json_outputter.py
+++ b/reclass/output/json_outputter.py
@@ -6,8 +6,14 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from reclass.output import OutputterBase
 import json
+
 
 class Outputter(OutputterBase):
 

--- a/reclass/output/yaml_outputter.py
+++ b/reclass/output/yaml_outputter.py
@@ -6,10 +6,16 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from reclass.output import OutputterBase
 import yaml
 
 _SafeDumper = yaml.CSafeDumper if yaml.__with_libyaml__ else yaml.SafeDumper
+
 
 class Outputter(OutputterBase):
 
@@ -18,6 +24,7 @@ class Outputter(OutputterBase):
             return yaml.dump(data, default_flow_style=not pretty_print, Dumper=ExplicitDumper)
         else:
             return yaml.dump(data, default_flow_style=not pretty_print, Dumper=_SafeDumper)
+
 
 class ExplicitDumper(_SafeDumper):
     """

--- a/reclass/settings.py
+++ b/reclass/settings.py
@@ -1,11 +1,15 @@
+# -*- coding: utf-8
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import copy
 import reclass.values.parser_funcs
 from reclass.defaults import *
 
-try:
-    basestring
-except NameError:
-    basestring = str
+from six import string_types
 
 class Settings(object):
 
@@ -27,7 +31,7 @@ class Settings(object):
         self.ignore_class_notfound = options.get('ignore_class_notfound', OPT_IGNORE_CLASS_NOTFOUND)
 
         self.ignore_class_notfound_regexp = options.get('ignore_class_notfound_regexp', OPT_IGNORE_CLASS_NOTFOUND_REGEXP)
-        if isinstance(self.ignore_class_notfound_regexp, basestring):
+        if isinstance(self.ignore_class_notfound_regexp, string_types):
             self.ignore_class_notfound_regexp = [ self.ignore_class_notfound_regexp ]
 
         self.ignore_class_notfound_warning = options.get('ignore_class_notfound_warning', OPT_IGNORE_CLASS_NOTFOUND_WARNING)

--- a/reclass/storage/__init__.py
+++ b/reclass/storage/__init__.py
@@ -6,6 +6,11 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 
 class NodeStorageBase(object):
 

--- a/reclass/storage/common.py
+++ b/reclass/storage/common.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import os
 
 class NameMangler:

--- a/reclass/storage/loader.py
+++ b/reclass/storage/loader.py
@@ -6,16 +6,20 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
-import importlib
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
+from importlib import import_module
 
 class StorageBackendLoader(object):
 
     def __init__(self, storage_name):
-        self._name = 'reclass.storage.' + storage_name
+        self._name = str('reclass.storage.' + storage_name)
         try:
-            self._module = importlib.import_module(self._name)
-        except ImportError:
+            self._module = import_module(self._name)
+        except ImportError as e:
             raise NotImplementedError
 
     def load(self, klassname='ExternalNodeStorage'):

--- a/reclass/storage/memcache_proxy.py
+++ b/reclass/storage/memcache_proxy.py
@@ -6,6 +6,10 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from reclass.storage import NodeStorageBase
 

--- a/reclass/storage/mixed/__init__.py
+++ b/reclass/storage/mixed/__init__.py
@@ -2,6 +2,10 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of reclass
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import collections
 import copy

--- a/reclass/storage/tests/__init__.py
+++ b/reclass/storage/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals

--- a/reclass/storage/tests/test_loader.py
+++ b/reclass/storage/tests/test_loader.py
@@ -6,9 +6,15 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from reclass.storage.loader import StorageBackendLoader
 
 import unittest
+
 
 class TestLoader(unittest.TestCase):
 

--- a/reclass/storage/tests/test_memcache_proxy.py
+++ b/reclass/storage/tests/test_memcache_proxy.py
@@ -6,16 +6,22 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from reclass.settings import Settings
 from reclass.storage.memcache_proxy import MemcacheProxy
 from reclass.storage import NodeStorageBase
 
 import unittest
+
 try:
     import unittest.mock as mock
 except ImportError:
     import mock
+
 
 class TestMemcacheProxy(unittest.TestCase):
 

--- a/reclass/storage/tests/test_yamldata.py
+++ b/reclass/storage/tests/test_yamldata.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass (http://github.com/madduck/reclass)
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from reclass.storage.yamldata import YamlData
 

--- a/reclass/storage/yaml_fs/__init__.py
+++ b/reclass/storage/yaml_fs/__init__.py
@@ -6,6 +6,11 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import os, sys
 import fnmatch
 import yaml
@@ -21,7 +26,7 @@ FILE_EXTENSION = '.yml'
 STORAGE_NAME = 'yaml_fs'
 
 def vvv(msg):
-    #print >>sys.stderr, msg
+    #print(msg, file=sys.stderr)
     pass
 
 def path_mangler(inventory_base_uri, nodes_uri, classes_uri):

--- a/reclass/storage/yaml_fs/directory.py
+++ b/reclass/storage/yaml_fs/directory.py
@@ -6,6 +6,11 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import os
 from reclass.errors import NotFoundError
 
@@ -13,7 +18,7 @@ SKIPDIRS = ('CVS', 'SCCS')
 FILE_EXTENSION = '.yml'
 
 def vvv(msg):
-    #print >>sys.stderr, msg
+    #print(msg, file=sys.stderr)
     pass
 
 

--- a/reclass/storage/yaml_git/__init__.py
+++ b/reclass/storage/yaml_git/__init__.py
@@ -2,6 +2,10 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of reclass
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import collections
 import distutils.version

--- a/reclass/storage/yamldata.py
+++ b/reclass/storage/yamldata.py
@@ -6,6 +6,11 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from reclass import datatypes
 import yaml
 import os

--- a/reclass/tests/__init__.py
+++ b/reclass/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals

--- a/reclass/tests/test_core.py
+++ b/reclass/tests/test_core.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass (http://github.com/madduck/reclass)
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 

--- a/reclass/utils/__init__.py
+++ b/reclass/utils/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals

--- a/reclass/utils/dictpath.py
+++ b/reclass/utils/dictpath.py
@@ -6,6 +6,10 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import six
 import re

--- a/reclass/utils/tests/__init__.py
+++ b/reclass/utils/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals

--- a/reclass/utils/tests/test_dictpath.py
+++ b/reclass/utils/tests/test_dictpath.py
@@ -6,6 +6,11 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from reclass.utils.dictpath import DictPath
 import unittest
 
@@ -64,7 +69,7 @@ class TestDictPath(unittest.TestCase):
         delim = '%'
         s = 'a:b\:b:c'
         p = DictPath(delim, s)
-        self.assertEqual('%r' % p, 'DictPath(%r, %r)' % (delim, s))
+        self.assertEqual('%r' % p, "DictPath(%r, %r)" % (delim, str(s)))
 
     def test_str(self):
         s = 'a:b\:b:c'

--- a/reclass/values/__init__.py
+++ b/reclass/values/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals

--- a/reclass/values/compitem.py
+++ b/reclass/values/compitem.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from reclass.settings import Settings
 from .item import Item

--- a/reclass/values/dictitem.py
+++ b/reclass/values/dictitem.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from reclass.settings import Settings
 from .item import Item

--- a/reclass/values/invitem.py
+++ b/reclass/values/invitem.py
@@ -3,11 +3,15 @@
 #
 # This file is part of reclass
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import copy
 import pyparsing as pp
 
-from six import iteritems
+from six import iteritems, string_types
 
 from .item import Item
 from reclass.settings import Settings
@@ -90,7 +94,7 @@ class Element(object):
             raise ResolveError(str(path))
 
     def _get_vars(self, var, export, parameter, value):
-        if isinstance(var, str):
+        if isinstance(var, string_types):
             path = DictPath(self._delimiter, var)
             if path.path[0].lower() == 'exports':
                 export = path

--- a/reclass/values/item.py
+++ b/reclass/values/item.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from reclass.utils.dictpath import DictPath
 

--- a/reclass/values/listitem.py
+++ b/reclass/values/listitem.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .item import Item
 from reclass.settings import Settings

--- a/reclass/values/parser.py
+++ b/reclass/values/parser.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import pyparsing as pp
 

--- a/reclass/values/parser_funcs.py
+++ b/reclass/values/parser_funcs.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import pyparsing as pp
 

--- a/reclass/values/refitem.py
+++ b/reclass/values/refitem.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .item import Item
 from reclass.defaults import REFERENCE_SENTINELS

--- a/reclass/values/scaitem.py
+++ b/reclass/values/scaitem.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from reclass.settings import Settings
 from .item import Item

--- a/reclass/values/tests/__init__.py
+++ b/reclass/values/tests/__init__.py
@@ -1,0 +1,7 @@
+#
+# -*- coding: utf-8
+#
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals

--- a/reclass/values/tests/test_value.py
+++ b/reclass/values/tests/test_value.py
@@ -6,6 +6,10 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import pyparsing as pp
 

--- a/reclass/values/value.py
+++ b/reclass/values/value.py
@@ -3,12 +3,18 @@
 #
 # This file is part of reclass
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .parser import Parser
 from .dictitem import DictItem
 from .listitem import ListItem
 from .scaitem import ScaItem
 from reclass.errors import InterpolationError
+
+from six import string_types
 
 class Value(object):
 
@@ -18,7 +24,7 @@ class Value(object):
         self._settings = settings
         self._uri = uri
         self._overwrite = False
-        if isinstance(value, str):
+        if isinstance(value, string_types):
             if parse_string:
                 try:
                     self._item = self._parser.parse(value, self._settings)

--- a/reclass/values/valuelist.py
+++ b/reclass/values/valuelist.py
@@ -3,6 +3,10 @@
 #
 # This file is part of reclass
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from __future__ import print_function
 

--- a/reclass/version.py
+++ b/reclass/version.py
@@ -6,6 +6,11 @@
 # Copyright © 2007–14 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 RECLASS_NAME = 'reclass'
 DESCRIPTION = 'merge data by recursive descent down an ancestry hierarchy (forked extended version)'
 VERSION = '1.5.3'

--- a/reclass/version.py
+++ b/reclass/version.py
@@ -8,7 +8,7 @@
 #
 RECLASS_NAME = 'reclass'
 DESCRIPTION = 'merge data by recursive descent down an ancestry hierarchy (forked extended version)'
-VERSION = '1.5.2'
+VERSION = '1.5.3'
 AUTHOR = 'martin f. krafft / Andrew Pickford / salt-formulas community'
 AUTHOR_EMAIL = 'salt-formulas@freelists.org'
 MAINTAINER = 'salt-formulas community'

--- a/reclass/version.py
+++ b/reclass/version.py
@@ -13,7 +13,7 @@ from __future__ import unicode_literals
 
 RECLASS_NAME = 'reclass'
 DESCRIPTION = 'merge data by recursive descent down an ancestry hierarchy (forked extended version)'
-VERSION = '1.5.3'
+VERSION = '1.5.4'
 AUTHOR = 'martin f. krafft / Andrew Pickford / salt-formulas community'
 AUTHOR_EMAIL = 'salt-formulas@freelists.org'
 MAINTAINER = 'salt-formulas community'

--- a/run_tests.py
+++ b/run_tests.py
@@ -6,6 +6,10 @@
 # Copyright © 2007–13 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import unittest
 tests = unittest.TestLoader().discover('reclass')

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,10 @@
 # Copyright © 2007–13 martin f. krafft <madduck@madduck.net>
 # Released under the terms of the Artistic Licence 2.0
 #
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from reclass.version import *
 from setuptools import setup, find_packages


### PR DESCRIPTION
Changelog:
Fixes usage with salt 2018.3.1 (unicode+literals)
Adds py2.7/3.6 compatibility, syntax updated to py3 