### PR TITLE
Add missing uri() method to valuelist class

### DIFF
--- a/reclass/values/valuelist.py
+++ b/reclass/values/valuelist.py
@@ -39,6 +39,9 @@ class ValueList(object):
         self.assembleRefs()
         self._check_for_inv_query()
 
+    def uri(self):
+        return '; '.join([ x.uri() for x in self._values ])
+
     def has_references(self):
         return len(self._refs) > 0
 


### PR DESCRIPTION
Simple addition of a uri() method to the valuelist class. The method is required if an InterpolationError is raised in a valuelist method, which is rare but possible.

The returned uri is a string concatenation of the uri's of the values contained in the valuelist. So while this doesn't return the exact location of the error it does narrow it down to the places the relevant parameter is defined in the reclass data.