### PR TITLE
Fix: use returned parameter from _render_simple_dict/list in exports class

### DIFF
--- a/reclass/datatypes/exports.py
+++ b/reclass/datatypes/exports.py
@@ -92,7 +92,7 @@ class Exports(Parameters):
             e.context = path
             raise
         if isinstance(new, dict):
-            self._render_simple_dict(new, path)
+            new = self._render_simple_dict(new, path)
         elif isinstance(new, list):
-            self._render_simple_list(new, path)
+            new = self._render_simple_list(new, path)
         return new

--- a/reclass/datatypes/tests/test_entity.py
+++ b/reclass/datatypes/tests/test_entity.py
@@ -167,6 +167,19 @@ class TestEntity(unittest.TestCase):
 
 class TestEntityNoMock(unittest.TestCase):
 
+    def test_interpolate_list_types(self):
+        node1_exports = Exports({'exps': [ '${one}' ] }, SETTINGS, 'first')
+        node1_parameters = Parameters({'alpha': [ '${two}', '${three}' ], 'one': 1, 'two': 2, 'three': 3 }, SETTINGS, 'first')
+        node1_entity = Entity(SETTINGS, classes=None, applications=None, parameters=node1_parameters, exports=node1_exports)
+        node2_exports = Exports({'exps': '${alpha}' }, SETTINGS, 'second')
+        node2_parameters = Parameters({}, SETTINGS, 'second')
+        node2_entity = Entity(SETTINGS, classes=None, applications=None, parameters=node2_parameters, exports=node2_exports)
+        r = {'exps': [ 1, 2, 3 ]}
+        node1_entity.merge(node2_entity)
+        node1_entity.interpolate(None)
+        self.assertIs(type(node1_entity.exports.as_dict()['exps']), list)
+        self.assertDictEqual(node1_entity.exports.as_dict(), r)
+
     def test_exports_with_refs(self):
         inventory = {'node1': {'a': 1, 'b': 2}, 'node2': {'a': 3, 'b': 4}}
         node3_exports = Exports({'a': '${a}', 'b': '${b}'}, SETTINGS, '')

--- a/reclass/datatypes/tests/test_exports.py
+++ b/reclass/datatypes/tests/test_exports.py
@@ -8,6 +8,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from reclass.utils.parameterdict import ParameterDict
+from reclass.utils.parameterlist import ParameterList
 from reclass.settings import Settings
 from reclass.datatypes import Exports, Parameters
 from reclass.errors import ParseError
@@ -23,6 +25,16 @@ class TestInvQuery(unittest.TestCase):
         e.overwrite(d)
         e.interpolate()
         self.assertEqual(e.as_dict(), d)
+
+    def test_interpolate_types(self):
+        e = Exports({'alpha': { 'one': 1, 'two': 2}, 'beta': [ 1, 2 ]}, SETTINGS, '')
+        r = {'alpha': { 'one': 1, 'two': 2}, 'beta': [ 1, 2 ]}
+        self.assertIs(type(e.as_dict()['alpha']), ParameterDict)
+        self.assertIs(type(e.as_dict()['beta']), ParameterList)
+        e.interpolate()
+        self.assertIs(type(e.as_dict()['alpha']), dict)
+        self.assertIs(type(e.as_dict()['beta']), list)
+        self.assertEqual(e.as_dict(), r)
 
     def test_malformed_invquery(self):
         with self.assertRaises(ParseError):

--- a/reclass/datatypes/tests/test_parameters.py
+++ b/reclass/datatypes/tests/test_parameters.py
@@ -18,7 +18,9 @@ from six import iteritems
 from reclass.settings import Settings
 from reclass.datatypes import Parameters
 from reclass.utils.parameterdict import ParameterDict
+from reclass.utils.parameterlist import ParameterList
 from reclass.values.value import Value
+from reclass.values.valuelist import ValueList
 from reclass.values.scaitem import ScaItem
 from reclass.errors import ChangedConstantError, InfiniteRecursionError, InterpolationError, ResolveError, ResolveErrorList, TypeMergeError
 import unittest
@@ -774,6 +776,46 @@ class TestParametersNoMock(unittest.TestCase):
         p1.merge(p2)
         p1.merge(p3)
         p1.interpolate()
+        self.assertEqual(p1.as_dict(), r)
+
+    def test_interpolated_list_type(self):
+        p1 = Parameters({'a': [ 1, 2, 3 ]}, SETTINGS, 'first')
+        r = {'a': [ 1, 2, 3 ]}
+        self.assertIs(type(p1.as_dict()['a']), ParameterList)
+        p1.interpolate()
+        self.assertIs(type(p1.as_dict()['a']), list)
+        self.assertEqual(p1.as_dict(), r)
+
+    def test_interpolated_dict_type(self):
+        p1 = Parameters({'a': { 'one': 1, 'two': 2, 'three': 3 }}, SETTINGS, 'first')
+        r = {'a': { 'one': 1, 'two': 2, 'three': 3 }}
+        self.assertIs(type(p1.as_dict()['a']), ParameterDict)
+        p1.interpolate()
+        self.assertIs(type(p1.as_dict()['a']), dict)
+        self.assertEqual(p1.as_dict(), r)
+
+    def test_merged_interpolated_list_type(self):
+        p1 = Parameters({'a': [ 1, 2, 3 ]}, SETTINGS, 'first')
+        p2 = Parameters({'a': [ 4, 5, 6 ]}, SETTINGS, 'second')
+        r = {'a': [ 1, 2, 3, 4, 5, 6 ]}
+        self.assertIs(type(p1.as_dict()['a']), ParameterList)
+        self.assertIs(type(p2.as_dict()['a']), ParameterList)
+        p1.merge(p2)
+        self.assertIs(type(p1.as_dict()['a']), ValueList)
+        p1.interpolate()
+        self.assertIs(type(p1.as_dict()['a']), list)
+        self.assertEqual(p1.as_dict(), r)
+
+    def test_merged_interpolated_dict_type(self):
+        p1 = Parameters({'a': { 'one': 1, 'two': 2, 'three': 3 }}, SETTINGS, 'first')
+        p2 = Parameters({'a': { 'four': 4, 'five': 5, 'six': 6 }}, SETTINGS, 'second')
+        r = {'a': { 'one': 1, 'two': 2, 'three': 3, 'four': 4, 'five': 5, 'six': 6}}
+        self.assertIs(type(p1.as_dict()['a']), ParameterDict)
+        self.assertIs(type(p2.as_dict()['a']), ParameterDict)
+        p1.merge(p2)
+        self.assertIs(type(p1.as_dict()['a']), ParameterDict)
+        p1.interpolate()
+        self.assertIs(type(p1.as_dict()['a']), dict)
         self.assertEqual(p1.as_dict(), r)
 
 


### PR DESCRIPTION
The Parameters._render_simple_dict and _render_simple_list methods now (see #52)
return a new dict or list instead of changing in place the dict or list
passed to them. This commit updates the exports class appropriately and
adds some additional tests for these changes.