### PR TITLE
Fix, usage of numeric keys

### DIFF
--- a/reclass/datatypes/parameters.py
+++ b/reclass/datatypes/parameters.py
@@ -170,6 +170,8 @@ class Parameters(object):
         """
 
         for (key, value) in iteritems(new):
+            # check key for "control" preffixes (~,=,...)
+            key = str(key)
             if key[0] in self._settings.dict_key_prefixes:
                 newkey = key[1:]
                 if not isinstance(value, Value):

--- a/test/model/default/classes/third.yml
+++ b/test/model/default/classes/third.yml
@@ -10,6 +10,12 @@ parameters:
       fail:
         at:
           tree: ${_param:notfound}
+  1:
+    an_numeric_key: true
+    as_a_dict: 1
+  2:
+  - as_a_list
+  3: value
   three: ${two}
   empty:
     list: []


### PR DESCRIPTION
In favor of #57
Convert key to string (repr), when using "key" as string/list.