### PR TITLE
Fix, class name references in 2nd level

### DIFF
--- a/reclass/core.py
+++ b/reclass/core.py
@@ -136,7 +136,7 @@ class Core(object):
                     e.uri = entity.uri
                     raise
 
-                descent = self._recurse_entity(class_entity, context=merge_base, seen=seen,
+                descent = self._recurse_entity(class_entity, context=context, seen=seen,
                                                nodename=nodename, environment=environment)
                 # on every iteration, we merge the result of the recursive
                 # descent into what we have so far…


### PR DESCRIPTION
Classes processed deeper in the "descent" had merge_base cleared (note, merge happens later, on line 143); then references that actually worked on 1st step failed on the another descend.

(no tests,I count to add additional test models later this month)