### PR TITLE
Fix invquery references bug introduced in refactoring

### DIFF
--- a/reclass/values/invitem.py
+++ b/reclass/values/invitem.py
@@ -110,8 +110,9 @@ class LogicTest(BaseTestExpression):
         subtests = list(it.compress(expr, it.cycle([1, 1, 1, 0])))
         self._els = [EqualityTest(subtests[j:j+3], self._delimiter)
                      for j in range(0, len(subtests), 3)]
-        self.refs = [x.refs for x in self._els]
-        self.inv_refs = [x.inv_refs for x in self._els]
+        for x in self._els:
+            self.refs.extend(x.refs)
+            self.inv_refs.extend(x.inv_refs)
         try:
             self._ops = [self.known_operators[x[1]] for x in expr[3::4]]
         except KeyError as e:


### PR DESCRIPTION
The refactoring introduced a bug in the master list of references (and invquery references) built up in LogicTest.\_\_init\_\_ in invitem.py. The references (and invquery references) from EqualityTest objects should be used to extend the master list not append to it.

Later parts of the code rely on the list of references being a flat list, without any sublists.