### PR TITLE
Update mixed and yaml_git for compose_node_name changes

### DIFF
--- a/reclass/storage/__init__.py
+++ b/reclass/storage/__init__.py
@@ -11,6 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from reclass.storage.common import NameMangler
 
 class NodeStorageBase(object):
 
@@ -34,3 +35,14 @@ class NodeStorageBase(object):
     def path_mangler(self):
         msg = "Storage class '{0}' does not implement path_mangler."
         raise NotImplementedError(msg.format(self.name))
+
+
+class ExternalNodeStorageBase(NodeStorageBase):
+
+    def __init__(self, name, compose_node_name):
+        super(ExternalNodeStorageBase, self).__init__(name)
+        self.class_name_mangler = NameMangler.classes
+        if compose_node_name:
+            self.node_name_mangler = NameMangler.composed_nodes
+        else:
+            self.node_name_mangler = NameMangler.nodes

--- a/reclass/storage/mixed/__init__.py
+++ b/reclass/storage/mixed/__init__.py
@@ -14,7 +14,7 @@ from six import iteritems
 
 import reclass.errors
 from reclass import get_storage
-from reclass.storage import NodeStorageBase
+from reclass.storage import ExternalNodeStorageBase
 
 def path_mangler(inventory_base_uri, nodes_uri, classes_uri):
     if nodes_uri == classes_uri:
@@ -23,17 +23,17 @@ def path_mangler(inventory_base_uri, nodes_uri, classes_uri):
 
 STORAGE_NAME = 'mixed'
 
-class ExternalNodeStorage(NodeStorageBase):
+class ExternalNodeStorage(ExternalNodeStorageBase):
 
     MixedUri = collections.namedtuple('MixedURI', 'storage_type options')
 
-    def __init__(self, nodes_uri, classes_uri):
-        super(ExternalNodeStorage, self).__init__(STORAGE_NAME)
+    def __init__(self, nodes_uri, classes_uri, compose_node_name):
+        super(ExternalNodeStorage, self).__init__(STORAGE_NAME, compose_node_name)
 
         self._nodes_uri = self._uri(nodes_uri)
-        self._nodes_storage = get_storage(self._nodes_uri.storage_type, self._nodes_uri.options, None)
+        self._nodes_storage = get_storage(self._nodes_uri.storage_type, self._nodes_uri.options, None, compose_node_name)
         self._classes_default_uri = self._uri(classes_uri)
-        self._classes_default_storage = get_storage(self._classes_default_uri.storage_type, None, self._classes_default_uri.options)
+        self._classes_default_storage = get_storage(self._classes_default_uri.storage_type, None, self._classes_default_uri.options, compose_node_name)
 
         self._classes_storage = dict()
         if 'env_overrides' in classes_uri:
@@ -42,7 +42,7 @@ class ExternalNodeStorage(NodeStorageBase):
                         uri = copy.deepcopy(classes_uri)
                         uri.update(options)
                         uri = self._uri(uri)
-                        self._classes_storage[env] = get_storage(uri.storage_type, None, uri.options)
+                        self._classes_storage[env] = get_storage(uri.storage_type, None, uri.options, compose_node_name)
 
     def _uri(self, uri):
         ret = copy.deepcopy(uri)

--- a/reclass/storage/yaml_fs/__init__.py
+++ b/reclass/storage/yaml_fs/__init__.py
@@ -15,8 +15,7 @@ import os, sys
 import fnmatch
 import yaml
 from reclass.output.yaml_outputter import ExplicitDumper
-from reclass.storage import NodeStorageBase
-from reclass.storage.common import NameMangler
+from reclass.storage import ExternalNodeStorageBase
 from reclass.storage.yamldata import YamlData
 from .directory import Directory
 from reclass.datatypes import Entity
@@ -53,22 +52,18 @@ def path_mangler(inventory_base_uri, nodes_uri, classes_uri):
     return n, c
 
 
-class ExternalNodeStorage(NodeStorageBase):
+class ExternalNodeStorage(ExternalNodeStorageBase):
 
     def __init__(self, nodes_uri, classes_uri, compose_node_name):
-        super(ExternalNodeStorage, self).__init__(STORAGE_NAME)
+        super(ExternalNodeStorage, self).__init__(STORAGE_NAME, compose_node_name)
 
         if nodes_uri is not None:
             self._nodes_uri = nodes_uri
-            if compose_node_name:
-                self._nodes = self._enumerate_inventory(nodes_uri, NameMangler.composed_nodes)
-            else:
-                self._nodes = self._enumerate_inventory(nodes_uri, NameMangler.nodes)
-
+            self._nodes = self._enumerate_inventory(nodes_uri, self.node_name_mangler)
 
         if classes_uri is not None:
             self._classes_uri = classes_uri
-            self._classes = self._enumerate_inventory(classes_uri, NameMangler.classes)
+            self._classes = self._enumerate_inventory(classes_uri, self.class_name_mangler)
 
     nodes_uri = property(lambda self: self._nodes_uri)
     classes_uri = property(lambda self: self._classes_uri)


### PR DESCRIPTION
This patch fixes method signatures in the mixed and yaml_git storage types to match the changes in yaml_fs with the addition of the compose_node_name option.

The base class of ExternalNodeStorage classes is changed from NodeStorageBase to ExternalNodeStorageBase (which has as it's base class NodeStorageBase). This allows the MemcacheProxy class to retain NodeStorageBase as it's base class and have the compose_node_name option name mangler selection moved into the ExternalNodeStorageBase class.

The selected name mangler functions are then available to any storage classes as:
self.class_name_mangler   and
self.node_name_mangler

Tested on my reclass configuration for the three storage types with compose_node_name=False. For compose_node_name=True mixed and yaml_fs storage types should be fine as the changes are small, but it would be nice to double check with a reclass config that uses compose_node_name=True.

For yaml_git storage using compose_node_name=True is an untested and not supported option for this patch. It should work fine, but unless someone needs to this it's very low priority which I don't want to have block the critical method signature fixes.