### PR TITLE
Fix merging inv query results

### DIFF
--- a/reclass/datatypes/tests/test_exports.py
+++ b/reclass/datatypes/tests/test_exports.py
@@ -120,5 +120,14 @@ class TestInvQuery(unittest.TestCase):
         p.interpolate(e)
         self.assertIn(p.as_dict(), [ r1, r2 ])
 
+    def test_merging_inv_queries(self):
+        e = {'node1': {'a': 1}, 'node2': {'a': 1}, 'node3': {'a': 2}}
+        p1 = Parameters({'exp': '$[ if exports:a == 1 ]'}, SETTINGS, '')
+        p2 = Parameters({'exp': '$[ if exports:a == 2 ]'}, SETTINGS, '')
+        r = { 'exp': [ 'node1', 'node2', 'node3' ] }
+        p1.merge(p2)
+        p1.interpolate(e)
+        self.assertEqual(p1.as_dict(), r)
+
 if __name__ == '__main__':
     unittest.main()

--- a/reclass/values/invitem.py
+++ b/reclass/values/invitem.py
@@ -189,6 +189,9 @@ class InvItem(item.Item):
     def get_references(self):
         return self._question.refs
 
+    def assembleRefs(self, context):
+        return
+
     def get_inv_references(self):
         return self.inv_refs
 

--- a/reclass/values/valuelist.py
+++ b/reclass/values/valuelist.py
@@ -71,9 +71,9 @@ class ValueList(object):
         self.ignore_failed_render = True
         for value in self._values:
             if value.has_inv_query:
-                self._inv_refs.extend(value.get_inv_references)
+                self._inv_refs.extend(value.get_inv_references())
                 self._has_inv_query = True
-                if vale.ignore_failed_render() is False:
+                if value.ignore_failed_render() is False:
                     self.ignore_failed_render = False
         if self._has_inv_query is False:
             self.ignore_failed_render = False
@@ -87,6 +87,13 @@ class ValueList(object):
                 self._refs.extend(value.get_references())
             if value.allRefs is False:
                 self.allRefs = False
+
+    @property
+    def needs_all_envs(self):
+        for value in self._values:
+            if value.needs_all_envs:
+                return True
+        return False
 
     def merge(self):
         output = None


### PR DESCRIPTION
Fixes merging the results of inventory queries. The following would fail previously, raising an exception when trying to merge the test parameter:

```yaml
# class/first.tml
exports:
  value: 1

parameters:
  test: $[ if exports:value == 1 ]

# class/second.yml
parameters:
  test: $[ if exports:value == 2 ]
```

This patch fixes a couple of typos and adds a couple of missing methods and a new test for merging inv queries.