### PR TITLE
fix relative class names

### DIFF
--- a/reclass/core.py
+++ b/reclass/core.py
@@ -123,10 +123,6 @@ class Core(object):
                     except ResolveError as e:
                         raise ClassNameResolveError(klass, nodename, entity.uri)
 
-            # for convenience, first level classes_uri/class.yml can have un-interpolated "."
-            if klass.startswith('.'):
-                klass = klass[1:]
-
             if klass not in seen:
                 try:
                     class_entity = self._storage.get_class(klass, environment, self._settings)

--- a/reclass/storage/yaml_fs/__init__.py
+++ b/reclass/storage/yaml_fs/__init__.py
@@ -96,7 +96,6 @@ class ExternalNodeStorage(ExternalNodeStorageBase):
         try:
             relpath = self._nodes[name]
             path = os.path.join(self.nodes_uri, relpath)
-            name = os.path.splitext(relpath)[0]
         except KeyError as e:
             raise reclass.errors.NodeNotFound(self.name, name, self.nodes_uri)
         entity = YamlData.from_file(path).get_entity(name, settings)
@@ -108,13 +107,7 @@ class ExternalNodeStorage(ExternalNodeStorageBase):
             path = os.path.join(self.classes_uri, self._classes[name])
         except KeyError as e:
             raise reclass.errors.ClassNotFound(self.name, name, self.classes_uri)
-
-        if path.endswith('init{}'.format(FILE_EXTENSION)):
-            parent_class=name
-        else:
-            # for regular class yml file, strip its name
-            parent_class='.'.join(name.split('.')[:-1])
-        entity = YamlData.from_file(path).get_entity(name, settings, parent_class)
+        entity = YamlData.from_file(path).get_entity(name, settings)
         return entity
 
     def enumerate_nodes(self):

--- a/reclass/storage/yaml_git/__init__.py
+++ b/reclass/storage/yaml_git/__init__.py
@@ -258,15 +258,7 @@ class ExternalNodeStorage(ExternalNodeStorageBase):
             raise reclass.errors.NotFoundError("File " + name + " missing from " + uri.repo + " branch " + uri.branch)
         file = self._repos[uri.repo].files[uri.branch][name]
         blob = self._repos[uri.repo].get(file.id)
-
-        if file.name.endswith('init{}'.format(FILE_EXTENSION)):
-            parent_class=name
-        else:
-            # for regular class yml file, strip its name
-            parent_class='.'.join(name.split('.')[:-1])
-
-        entity = YamlData.from_string(blob.data, 'git_fs://{0} {1} {2}'.format(uri.repo, uri.branch,
-            file.path)).get_entity(name, settings, parent_class)
+        entity = YamlData.from_string(blob.data, 'git_fs://{0} {1} {2}'.format(uri.repo, uri.branch, file.path)).get_entity(name, settings)
         return entity
 
     def enumerate_nodes(self):

--- a/reclass/storage/yamldata.py
+++ b/reclass/storage/yamldata.py
@@ -53,16 +53,26 @@ class YamlData(object):
     def get_data(self):
         return self._data
 
-    def get_entity(self, name, settings, parent_class=None):
+    def set_absolute_names(self, name, names):
+        parent = '.'.join(name.split('.')[0:-1])
+        new_names = []
+        for n in names:
+            if n[0] == '.':
+                if parent == '':
+                    n = n[1:]
+                else:
+                    n = parent + n
+            new_names.append(n)
+        return new_names
+
+    def get_entity(self, name, settings):
         #if name is None:
         #    name = self._uri
 
         classes = self._data.get('classes')
         if classes is None:
             classes = []
-        if parent_class:
-            classes = \
-                [parent_class + c for c in classes if c.startswith('.')]
+        classes = self.set_absolute_names(name, classes)
         classes = datatypes.Classes(classes)
 
         applications = self._data.get('applications')

--- a/reclass/tests/data/02/classes/one/alpha.yml
+++ b/reclass/tests/data/02/classes/one/alpha.yml
@@ -1,0 +1,7 @@
+classes:
+- .beta
+- two.beta
+
+parameters:
+  test1: ${one_beta}
+  test2: ${two_beta}

--- a/reclass/tests/data/02/classes/one/beta.yml
+++ b/reclass/tests/data/02/classes/one/beta.yml
@@ -1,0 +1,2 @@
+parameters:
+  one_beta: 1

--- a/reclass/tests/data/02/classes/three.yml
+++ b/reclass/tests/data/02/classes/three.yml
@@ -1,0 +1,2 @@
+classes:
+- .one.alpha

--- a/reclass/tests/data/02/classes/two/beta.yml
+++ b/reclass/tests/data/02/classes/two/beta.yml
@@ -1,0 +1,2 @@
+parameters:
+  two_beta: 2

--- a/reclass/tests/data/02/nodes/relative.yml
+++ b/reclass/tests/data/02/nodes/relative.yml
@@ -1,0 +1,2 @@
+classes:
+  - one.alpha

--- a/reclass/tests/data/02/nodes/top_relative.yml
+++ b/reclass/tests/data/02/nodes/top_relative.yml
@@ -1,0 +1,2 @@
+classes:
+  - three

--- a/reclass/tests/data/03/classes/a.yml
+++ b/reclass/tests/data/03/classes/a.yml
@@ -1,0 +1,6 @@
+parameters:
+  a: 1
+  alpha:
+  - ${a}
+  beta:
+    a: ${a}

--- a/reclass/tests/data/03/classes/b.yml
+++ b/reclass/tests/data/03/classes/b.yml
@@ -1,0 +1,6 @@
+parameters:
+  b: 2
+  alpha:
+  - ${b}
+  beta:
+    b: ${b}

--- a/reclass/tests/data/03/classes/c.yml
+++ b/reclass/tests/data/03/classes/c.yml
@@ -1,0 +1,6 @@
+parameters:
+  c: 3
+  alpha:
+  - ${c}
+  beta:
+    c: ${c}

--- a/reclass/tests/data/03/classes/d.yml
+++ b/reclass/tests/data/03/classes/d.yml
@@ -1,0 +1,6 @@
+parameters:
+  d: 4
+  alpha:
+  - ${d}
+  beta:
+    d: ${d}

--- a/reclass/tests/data/03/nodes/alpha/one.yml
+++ b/reclass/tests/data/03/nodes/alpha/one.yml
@@ -1,0 +1,3 @@
+classes:
+- a
+- b

--- a/reclass/tests/data/03/nodes/alpha/two.yml
+++ b/reclass/tests/data/03/nodes/alpha/two.yml
@@ -1,0 +1,3 @@
+classes:
+- a
+- c

--- a/reclass/tests/data/03/nodes/beta/one.yml
+++ b/reclass/tests/data/03/nodes/beta/one.yml
@@ -1,0 +1,3 @@
+classes:
+- b
+- c

--- a/reclass/tests/data/03/nodes/beta/two.yml
+++ b/reclass/tests/data/03/nodes/beta/two.yml
@@ -1,0 +1,3 @@
+classes:
+- c
+- d

--- a/reclass/tests/test_core.py
+++ b/reclass/tests/test_core.py
@@ -59,6 +59,18 @@ class TestCore(unittest.TestCase):
         params = { 'node_test': 'class not found', '_reclass_': { 'environment': 'base', 'name': {'full': 'class_notfound', 'short': 'class_notfound' } } }
         self.assertEqual(node['parameters'], params)
 
+    def test_relative_class_names(self):
+        reclass = self._core('02')
+        node = reclass.nodeinfo('relative')
+        params = { 'test1': 1, 'test2': 2, 'one_beta': 1, 'two_beta': 2, '_reclass_': { 'environment': 'base', 'name': { 'full': 'relative', 'short': 'relative' } } }
+        self.assertEqual(node['parameters'], params)
+
+    def test_top_relative_class_names(self):
+        reclass = self._core('02')
+        node = reclass.nodeinfo('top_relative')
+        params = { 'test1': 1, 'test2': 2, 'one_beta': 1, 'two_beta': 2, '_reclass_': { 'environment': 'base', 'name': { 'full': 'top_relative', 'short': 'top_relative' } } }
+        self.assertEqual(node['parameters'], params)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/reclass/tests/test_core.py
+++ b/reclass/tests/test_core.py
@@ -71,6 +71,21 @@ class TestCore(unittest.TestCase):
         params = { 'test1': 1, 'test2': 2, 'one_beta': 1, 'two_beta': 2, '_reclass_': { 'environment': 'base', 'name': { 'full': 'top_relative', 'short': 'top_relative' } } }
         self.assertEqual(node['parameters'], params)
 
+    def test_compose_node_names(self):
+        reclass = self._core('03', {'compose_node_name': True})
+        alpha_one_node = reclass.nodeinfo('alpha.one')
+        alpha_one_res = {'a': 1, 'alpha': [1, 2], 'beta': {'a': 1, 'b': 2}, 'b': 2, '_reclass_': {'environment': 'base', 'name': {'full': 'alpha.one', 'short': 'alpha'}}}
+        alpha_two_node = reclass.nodeinfo('alpha.two')
+        alpha_two_res = {'a': 1, 'alpha': [1, 3], 'beta': {'a': 1, 'c': 3}, 'c': 3, '_reclass_': {'environment': 'base', 'name': {'full': 'alpha.two', 'short': 'alpha'}}}
+        beta_one_node = reclass.nodeinfo('beta.one')
+        beta_one_res = {'alpha': [2, 3], 'beta': {'c': 3, 'b': 2}, 'b': 2, 'c': 3, '_reclass_': {'environment': 'base', 'name': {'full': 'beta.one', 'short': 'beta'}}}
+        beta_two_node = reclass.nodeinfo('beta.two')
+        beta_two_res = {'alpha': [3, 4], 'c': 3, 'beta': {'c': 3, 'd': 4}, 'd': 4, '_reclass_': {'environment': u'base', 'name': {'full': u'beta.two', 'short': u'beta'}}}
+        self.assertEqual(alpha_one_node['parameters'], alpha_one_res)
+        self.assertEqual(alpha_two_node['parameters'], alpha_two_res)
+        self.assertEqual(beta_one_node['parameters'], beta_one_res)
+        self.assertEqual(beta_two_node['parameters'], beta_two_res)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The implementation of the relative class name functionality has some bugs, leading to parameters not being correctly set. For example with:
```yaml
# nodes/node1.yml
classes:
- one.alpha

# classes/one/alpha.yml
classes:
- .beta
- two.beta

parameters:
  test1: ${one_beta}
  test2: ${two_beta}

# classes/one/beta.yml
parameters:
  one_beta: 1

# classes/two/beta.yml
parameters:
  two_beta: 2
```

then a nodeinfo fails:

```
reclass.py --nodeinfo node1
-> node1
   Cannot resolve ${two_beta}, at test2, in yaml_fs:///some_path/classes/one/alpha.yml
```
It looks like the class two.beta does not get loaded so the two_beta parameter never gets set.

This patch reworks relative class names by converting any relative class names to absolute class names when first encountered in the YamlData.get_entity method. Some additional tests for relative class names and the compose class name option are also added.