### PR TITLE
added support for .yaml along with .yml

### DIFF
--- a/reclass/storage/yaml_fs/__init__.py
+++ b/reclass/storage/yaml_fs/__init__.py
@@ -21,7 +21,7 @@ from .directory import Directory
 from reclass.datatypes import Entity
 import reclass.errors
 
-FILE_EXTENSION = '.yml'
+FILE_EXTENSION = ('.yml', '.yaml')
 STORAGE_NAME = 'yaml_fs'
 
 def vvv(msg):
@@ -71,7 +71,7 @@ class ExternalNodeStorage(ExternalNodeStorageBase):
     def _enumerate_inventory(self, basedir, name_mangler):
         ret = {}
         def register_fn(dirpath, filenames):
-            filenames = fnmatch.filter(filenames, '*{0}'.format(FILE_EXTENSION))
+            filenames = [f for f in filenames if f.endswith(FILE_EXTENSION)]
             vvv('REGISTER {0} in path {1}'.format(filenames, dirpath))
             for f in filenames:
                 name = os.path.splitext(f)[0]

--- a/reclass/storage/yaml_fs/__init__.py
+++ b/reclass/storage/yaml_fs/__init__.py
@@ -12,7 +12,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os, sys
-import fnmatch
 import yaml
 from reclass.output.yaml_outputter import ExplicitDumper
 from reclass.storage import ExternalNodeStorageBase

--- a/reclass/storage/yaml_fs/directory.py
+++ b/reclass/storage/yaml_fs/directory.py
@@ -15,7 +15,7 @@ import os
 from reclass.errors import NotFoundError
 
 SKIPDIRS = ('CVS', 'SCCS')
-FILE_EXTENSION = '.yml'
+FILE_EXTENSION = ('.yml', '.yaml')
 
 def vvv(msg):
     #print(msg, file=sys.stderr)

--- a/reclass/storage/yaml_git/__init__.py
+++ b/reclass/storage/yaml_git/__init__.py
@@ -34,7 +34,7 @@ import reclass.errors
 from reclass.storage import ExternalNodeStorageBase
 from reclass.storage.yamldata import YamlData
 
-FILE_EXTENSION = '.yml'
+FILE_EXTENSION = ('.yml', '.yaml')
 STORAGE_NAME = 'yaml_git'
 
 def path_mangler(inventory_base_uri, nodes_uri, classes_uri):
@@ -213,7 +213,7 @@ class GitRepo(object):
             branch = {}
             files = self.files_in_branch(bname)
             for file in files:
-                if fnmatch.fnmatch(file.name, '*{0}'.format(FILE_EXTENSION)):
+                if str(file.name).endswith(FILE_EXTENSION):
                     name = os.path.splitext(file.name)[0]
                     relpath = os.path.dirname(file.path)
                     if callable(self._class_name_mangler):

--- a/reclass/storage/yaml_git/__init__.py
+++ b/reclass/storage/yaml_git/__init__.py
@@ -11,7 +11,6 @@ import collections
 import distutils.version
 import errno
 import fcntl
-import fnmatch
 import os
 import time
 

--- a/reclass/storage/yaml_git/__init__.py
+++ b/reclass/storage/yaml_git/__init__.py
@@ -212,7 +212,7 @@ class GitRepo(object):
             branch = {}
             files = self.files_in_branch(bname)
             for file in files:
-                if str(file.name).endswith(FILE_EXTENSION):
+                if file.name.endswith(FILE_EXTENSION):
                     name = os.path.splitext(file.name)[0]
                     relpath = os.path.dirname(file.path)
                     if callable(self._class_name_mangler):


### PR DESCRIPTION
Fixes https://github.com/salt-formulas/reclass/issues/83 
As discussed before adding support for arbitrary extensions is not a good idea but we can defintely add support for .yaml extension.

As fnmatch was doing simple extension matching so I removed it and used simple endswith function as I was unable to find cleaner API which can utilize fnmatch.filter(...) with list of patterns. Let me know your thoughts on this. 