### PR TITLE
add Python3.7 compatibility

### DIFF
--- a/reclass/storage/yaml_git/__init__.py
+++ b/reclass/storage/yaml_git/__init__.py
@@ -42,7 +42,7 @@ def path_mangler(inventory_base_uri, nodes_uri, classes_uri):
     return nodes_uri, classes_uri
 
 
-GitMD = collections.namedtuple('GitMD', ['name', 'path', 'id'], verbose=False, rename=False)
+GitMD = collections.namedtuple('GitMD', ['name', 'path', 'id'], rename=False)
 
 
 class GitURI(object):


### PR DESCRIPTION
See https://docs.python.org/3/library/collections.html#namedtuple-factory-function-for-tuples-with-named-fields :
`Changed in version 3.7: Removed the verbose parameter `