### PR TITLE
fix yaml git error reporting

### DIFF
--- a/reclass/errors.py
+++ b/reclass/errors.py
@@ -117,7 +117,7 @@ class NodeNotFound(NotFoundError):
 
 class InterpolationError(ReclassException):
 
-    def __init__(self, msg, rc=posix.EX_DATAERR, nodename='', uri=None, context=None, tbFlag=True):
+    def __init__(self, msg=None, rc=posix.EX_DATAERR, nodename='', uri=None, context=None, tbFlag=True):
         super(InterpolationError, self).__init__(rc=rc, msg=msg, tbFlag=tbFlag)
         self.nodename = nodename
         self.uri = uri
@@ -330,7 +330,7 @@ class MappingFormatError(MappingError):
 
 class NameError(ReclassException):
 
-    def __init__(self, msg, rc=posix.EX_DATAERR):
+    def __init__(self, msg=None, rc=posix.EX_DATAERR):
         super(NameError, self).__init__(rc=rc, msg=msg)
 
 

--- a/reclass/storage/yaml_git/__init__.py
+++ b/reclass/storage/yaml_git/__init__.py
@@ -218,7 +218,7 @@ class GitRepo(object):
                     if callable(self._class_name_mangler):
                         relpath, name = self._class_name_mangler(relpath, name)
                     if name in ret:
-                        raise reclass.errors.DuplicateNodeNameError(self.name + ' - ' + bname, name, ret[name], path)
+                        raise reclass.errors.DuplicateNodeNameError(self.url + ' - ' + bname, name, ret[name], file)
                     else:
                         branch[name] = file
             ret[bname] = branch
@@ -233,7 +233,7 @@ class GitRepo(object):
                 if callable(self._node_name_mangler):
                     relpath, node_name = self._node_name_mangler(relpath, node_name)
                 if node_name in ret:
-                    raise reclass.errors.DuplicateNodeNameError(self.name, name, files[name], path)
+                    raise reclass.errors.DuplicateNodeNameError(self.url, name, ret[node_name].path, file.path)
                 else:
                     ret[node_name] = file
         return ret


### PR DESCRIPTION
Report the correct paths and urls when raising a DuplicateNodeNameError for the yaml git storage.

Also do a minor tidy up to the base error classes InterpolationError and NameError to make msg an optional parameter with a default of None. This mirrors how classes derived from InterpolationError and NameError use the msg parameter.

This has been running on our production system for the past six months.