### PR TITLE
Fix identical inventory queries with different flags returning incorrect data

### DIFF
--- a/reclass/datatypes/tests/test_exports.py
+++ b/reclass/datatypes/tests/test_exports.py
@@ -8,33 +8,39 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from six import iteritems
+
 from reclass.utils.parameterdict import ParameterDict
 from reclass.utils.parameterlist import ParameterList
 from reclass.settings import Settings
 from reclass.datatypes import Exports, Parameters
 from reclass.errors import ParseError
+from reclass.values import NodeInventory
 import unittest
 
 SETTINGS = Settings()
 
 class TestInvQuery(unittest.TestCase):
 
+    def _make_inventory(self, nodes):
+        return { name: NodeInventory(node, True) for name, node in iteritems(nodes) }
+
     def test_overwrite_method(self):
-        e = Exports({'alpha': { 'one': 1, 'two': 2}}, SETTINGS, '')
-        d = {'alpha': { 'three': 3, 'four': 4}}
-        e.overwrite(d)
-        e.interpolate()
-        self.assertEqual(e.as_dict(), d)
+        exports = Exports({'alpha': { 'one': 1, 'two': 2}}, SETTINGS, '')
+        data = {'alpha': { 'three': 3, 'four': 4}}
+        exports.overwrite(data)
+        exports.interpolate()
+        self.assertEqual(exports.as_dict(), data)
 
     def test_interpolate_types(self):
-        e = Exports({'alpha': { 'one': 1, 'two': 2}, 'beta': [ 1, 2 ]}, SETTINGS, '')
-        r = {'alpha': { 'one': 1, 'two': 2}, 'beta': [ 1, 2 ]}
-        self.assertIs(type(e.as_dict()['alpha']), ParameterDict)
-        self.assertIs(type(e.as_dict()['beta']), ParameterList)
-        e.interpolate()
-        self.assertIs(type(e.as_dict()['alpha']), dict)
-        self.assertIs(type(e.as_dict()['beta']), list)
-        self.assertEqual(e.as_dict(), r)
+        exports = Exports({'alpha': { 'one': 1, 'two': 2}, 'beta': [ 1, 2 ]}, SETTINGS, '')
+        result = {'alpha': { 'one': 1, 'two': 2}, 'beta': [ 1, 2 ]}
+        self.assertIs(type(exports.as_dict()['alpha']), ParameterDict)
+        self.assertIs(type(exports.as_dict()['beta']), ParameterList)
+        exports.interpolate()
+        self.assertIs(type(exports.as_dict()['alpha']), dict)
+        self.assertIs(type(exports.as_dict()['beta']), list)
+        self.assertEqual(exports.as_dict(), result)
 
     def test_malformed_invquery(self):
         with self.assertRaises(ParseError):
@@ -51,83 +57,121 @@ class TestInvQuery(unittest.TestCase):
             p = Parameters({'exp': '$[ exports:a if exports:b == self:test_value anddd exports:c == self:test_value2 ]'}, SETTINGS, '')
 
     def test_value_expr_invquery(self):
-        e = {'node1': {'a': 1, 'b': 2}, 'node2': {'a': 3, 'b': 4}}
-        p = Parameters({'exp': '$[ exports:a ]'}, SETTINGS, '')
-        r = {'exp': {'node1': 1, 'node2': 3}}
-        p.interpolate(e)
-        self.assertEqual(p.as_dict(), r)
+        inventory = self._make_inventory({'node1': {'a': 1, 'b': 2}, 'node2': {'a': 3, 'b': 4}})
+        parameters = Parameters({'exp': '$[ exports:a ]'}, SETTINGS, '')
+        result = {'exp': {'node1': 1, 'node2': 3}}
+        parameters.interpolate(inventory)
+        self.assertEqual(parameters.as_dict(), result)
 
     def test_if_expr_invquery(self):
-        e = {'node1': {'a': 1, 'b': 2}, 'node2': {'a': 3, 'b': 4}}
-        p = Parameters({'exp': '$[ exports:a if exports:b == 4 ]'}, SETTINGS, '')
-        r = {'exp': {'node2': 3}}
-        p.interpolate(e)
-        self.assertEqual(p.as_dict(), r)
+        inventory = self._make_inventory({'node1': {'a': 1, 'b': 2}, 'node2': {'a': 3, 'b': 4}})
+        parameters = Parameters({'exp': '$[ exports:a if exports:b == 4 ]'}, SETTINGS, '')
+        result = {'exp': {'node2': 3}}
+        parameters.interpolate(inventory)
+        self.assertEqual(parameters.as_dict(), result)
 
     def test_if_expr_invquery_with_refs(self):
-        e = {'node1': {'a': 1, 'b': 2}, 'node2': {'a': 3, 'b': 4}}
-        p = Parameters({'exp': '$[ exports:a if exports:b == self:test_value ]', 'test_value': 2}, SETTINGS, '')
-        r = {'exp': {'node1': 1}, 'test_value': 2}
-        p.interpolate(e)
-        self.assertEqual(p.as_dict(), r)
+        inventory = self._make_inventory({'node1': {'a': 1, 'b': 2}, 'node2': {'a': 3, 'b': 4}})
+        parameters = Parameters({'exp': '$[ exports:a if exports:b == self:test_value ]', 'test_value': 2}, SETTINGS, '')
+        result = {'exp': {'node1': 1}, 'test_value': 2}
+        parameters.interpolate(inventory)
+        self.assertEqual(parameters.as_dict(), result)
 
     def test_list_if_expr_invquery(self):
-        e = {'node1': {'a': 1, 'b': 2}, 'node2': {'a': 3, 'b': 3}, 'node3': {'a': 3, 'b': 2}}
-        p = Parameters({'exp': '$[ if exports:b == 2 ]'}, SETTINGS, '')
-        r1 = {'exp': ['node1', 'node3']}
-        r2 = {'exp': ['node3', 'node1']}
-        p.interpolate(e)
-        self.assertIn(p.as_dict(), [ r1, r2 ])
+        inventory = self._make_inventory({'node1': {'a': 1, 'b': 2}, 'node2': {'a': 3, 'b': 3}, 'node3': {'a': 3, 'b': 2}})
+        parameters = Parameters({'exp': '$[ if exports:b == 2 ]'}, SETTINGS, '')
+        result = {'exp': ['node1', 'node3']}
+        parameters.interpolate(inventory)
+        self.assertEqual(parameters.as_dict(), result)
 
     def test_if_expr_invquery_wth_and(self):
-        e = {'node1': {'a': 1, 'b': 4, 'c': False}, 'node2': {'a': 3, 'b': 4, 'c': True}}
-        p = Parameters({'exp': '$[ exports:a if exports:b == 4 and exports:c == True ]'}, SETTINGS, '')
-        r = {'exp': {'node2': 3}}
-        p.interpolate(e)
-        self.assertEqual(p.as_dict(), r)
+        inventory = self._make_inventory({'node1': {'a': 1, 'b': 4, 'c': False}, 'node2': {'a': 3, 'b': 4, 'c': True}})
+        parameters = Parameters({'exp': '$[ exports:a if exports:b == 4 and exports:c == True ]'}, SETTINGS, '')
+        result = {'exp': {'node2': 3}}
+        parameters.interpolate(inventory)
+        self.assertEqual(parameters.as_dict(), result)
 
     def test_if_expr_invquery_wth_or(self):
-        e = {'node1': {'a': 1, 'b': 4}, 'node2': {'a': 3, 'b': 3}}
-        p = Parameters({'exp': '$[ exports:a if exports:b == 4 or exports:b == 3 ]'}, SETTINGS, '')
-        r = {'exp': {'node1': 1, 'node2': 3}}
-        p.interpolate(e)
-        self.assertEqual(p.as_dict(), r)
+        inventory = self._make_inventory({'node1': {'a': 1, 'b': 4}, 'node2': {'a': 3, 'b': 3}})
+        parameters = Parameters({'exp': '$[ exports:a if exports:b == 4 or exports:b == 3 ]'}, SETTINGS, '')
+        result = {'exp': {'node1': 1, 'node2': 3}}
+        parameters.interpolate(inventory)
+        self.assertEqual(parameters.as_dict(), result)
 
     def test_list_if_expr_invquery_with_and(self):
-        e = {'node1': {'a': 1, 'b': 2, 'c': 'green'}, 'node2': {'a': 3, 'b': 3}, 'node3': {'a': 3, 'b': 2, 'c': 'red'}}
-        p = Parameters({'exp': '$[ if exports:b == 2 and exports:c == green ]'}, SETTINGS, '')
-        r = {'exp': ['node1']}
-        p.interpolate(e)
-        self.assertEqual(p.as_dict(), r)
+        inventory = self._make_inventory(
+                        { 'node1': {'a': 1, 'b': 2, 'c': 'green'},
+                          'node2': {'a': 3, 'b': 3},
+                          'node3': {'a': 3, 'b': 2, 'c': 'red'} })
+        parameters = Parameters({'exp': '$[ if exports:b == 2 and exports:c == green ]'}, SETTINGS, '')
+        result = {'exp': ['node1']}
+        parameters.interpolate(inventory)
+        self.assertEqual(parameters.as_dict(), result)
 
     def test_list_if_expr_invquery_with_and_missing(self):
-        inventory = {'node1': {'a': 1, 'b': 2, 'c': 'green'},
-                     'node2': {'a': 3, 'b': 3},
-                     'node3': {'a': 3, 'b': 2}}
+        inventory = self._make_inventory({'node1': {'a': 1, 'b': 2, 'c': 'green'},
+                                          'node2': {'a': 3, 'b': 3},
+                                          'node3': {'a': 3, 'b': 2}})
         mapping = {'exp': '$[ if exports:b == 2 and exports:c == green ]'}
         expected = {'exp': ['node1']}
+        parameterss = Parameters(mapping, SETTINGS, '')
+        parameterss.interpolate(inventory)
+        self.assertEqual(parameterss.as_dict(), expected)
 
-        pars = Parameters(mapping, SETTINGS, '')
-        pars.interpolate(inventory)
-
-        self.assertEqual(pars.as_dict(), expected)
-
-    def test_list_if_expr_invquery_with_and(self):
-        e = {'node1': {'a': 1, 'b': 2}, 'node2': {'a': 3, 'b': 3}, 'node3': {'a': 3, 'b': 4}}
-        p = Parameters({'exp': '$[ if exports:b == 2 or exports:b == 4 ]'}, SETTINGS, '')
-        r1 = {'exp': ['node1', 'node3']}
-        r2 = {'exp': ['node3', 'node1']}
-        p.interpolate(e)
-        self.assertIn(p.as_dict(), [ r1, r2 ])
+    def test_list_if_expr_invquery_with_or(self):
+        inventory = self._make_inventory(
+                        { 'node1': {'a': 1, 'b': 2},
+                          'node2': {'a': 3, 'b': 3},
+                          'node3': {'a': 3, 'b': 4} })
+        parameters = Parameters({'exp': '$[ if exports:b == 2 or exports:b == 4 ]'}, SETTINGS, '')
+        result = {'exp': ['node1', 'node3']}
+        parameters.interpolate(inventory)
+        self.assertEqual(parameters.as_dict(), result)
 
     def test_merging_inv_queries(self):
-        e = {'node1': {'a': 1}, 'node2': {'a': 1}, 'node3': {'a': 2}}
-        p1 = Parameters({'exp': '$[ if exports:a == 1 ]'}, SETTINGS, '')
-        p2 = Parameters({'exp': '$[ if exports:a == 2 ]'}, SETTINGS, '')
-        r = { 'exp': [ 'node1', 'node2', 'node3' ] }
-        p1.merge(p2)
-        p1.interpolate(e)
-        self.assertEqual(p1.as_dict(), r)
+        inventory = self._make_inventory({'node1': {'a': 1}, 'node2': {'a': 1}, 'node3': {'a': 2}})
+        pars1 = Parameters({'exp': '$[ if exports:a == 1 ]'}, SETTINGS, '')
+        pars2 = Parameters({'exp': '$[ if exports:a == 2 ]'}, SETTINGS, '')
+        result = { 'exp': [ 'node1', 'node2', 'node3' ] }
+        pars1.merge(pars2)
+        pars1.interpolate(inventory)
+        self.assertEqual(pars1.as_dict(), result)
+
+    def test_same_expr_invquery_different_flags(self):
+        inventory = { 'node1': NodeInventory({'a': 1}, True),
+                      'node2': NodeInventory({'a': 2}, True),
+                      'node3': NodeInventory({'a': 3}, False) }
+        parameters = Parameters({'alpha': '$[ exports:a ]', 'beta': '$[ +AllEnvs exports:a ]'}, SETTINGS, '')
+        result = { 'alpha': { 'node1': 1, 'node2': 2 },
+                   'beta': { 'node1': 1 , 'node2': 2, 'node3': 3 } }
+        parameters.interpolate(inventory)
+        self.assertEqual(parameters.as_dict(), result)
+
+    def test_same_if_expr_invquery_different_flags(self):
+        inventory = { 'node1': NodeInventory({'a': 1, 'b': 1}, True),
+                      'node2': NodeInventory({'a': 2, 'b': 2}, True),
+                      'node3': NodeInventory({'a': 3, 'b': 2}, False) }
+        parameters = Parameters(
+                         { 'alpha': '$[ exports:a if exports:b == 2 ]',
+                           'beta': '$[ +AllEnvs exports:a if exports:b == 2]' },
+                         SETTINGS, '')
+        result = { 'alpha': { 'node2': 2 },
+                   'beta': { 'node2': 2, 'node3': 3 } }
+        parameters.interpolate(inventory)
+        self.assertEqual(parameters.as_dict(), result)
+
+    def test_same_list_if_expr_invquery_different_flags(self):
+        inventory = { 'node1': NodeInventory({'a': 1}, True),
+                      'node2': NodeInventory({'a': 2}, True),
+                      'node3': NodeInventory({'a': 2}, False) }
+        parameters = Parameters(
+                         { 'alpha': '$[ if exports:a == 2 ]',
+                           'beta': '$[ +AllEnvs if exports:a == 2]' },
+                         SETTINGS, '')
+        result = { 'alpha': [ 'node2' ],
+                   'beta': [ 'node2', 'node3' ] }
+        parameters.interpolate(inventory)
+        self.assertEqual(parameters.as_dict(), result)
 
 if __name__ == '__main__':
     unittest.main()

--- a/reclass/values/__init__.py
+++ b/reclass/values/__init__.py
@@ -3,3 +3,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+
+import collections
+
+NodeInventory = collections.namedtuple('NodeInventory', ['items', 'env_matches'], rename=False)


### PR DESCRIPTION
With two identical inventory queries, one with the AllEnvs flag and one without both queries return the data from the query with the AllEnvs flag set.

Inventory queries use a pre calculated list of nodes to loop over to determine which nodes match the inventory query. If any inventory queries have the AllEnvs flag set then nodes from all environments will be present in the pre calculated list of nodes. Thus other queries which do not have the AllEnvs flags set could then match nodes from other environments.

The fix adds a test to the invitem class when assembling the inventory query result to check that the node environments match or that the query has the AllEnvs flag set. Unit tests are also added to check this functionality.

