### PR TITLE
Fix running 'python run_tests.py' without mock installed systemwide

### DIFF
--- a/reclass/values/tests/test_item.py
+++ b/reclass/values/tests/test_item.py
@@ -8,7 +8,10 @@ from reclass.values.dictitem import DictItem
 from reclass.values.item import ContainerItem
 from reclass.values.item import ItemWithReferences
 import unittest
-from mock import MagicMock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 
 SETTINGS = Settings()
 
@@ -16,7 +19,7 @@ SETTINGS = Settings()
 class TestItemWithReferences(unittest.TestCase):
 
     def test_assembleRef_allrefs(self):
-        phonyitem = MagicMock()
+        phonyitem = mock.MagicMock()
         phonyitem.has_references = True
         phonyitem.get_references = lambda *x: [1]
 
@@ -26,7 +29,7 @@ class TestItemWithReferences(unittest.TestCase):
         self.assertTrue(iwr.allRefs)
 
     def test_assembleRef_partial(self):
-        phonyitem = MagicMock()
+        phonyitem = mock.MagicMock()
         phonyitem.has_references = True
         phonyitem.allRefs = False
         phonyitem.get_references = lambda *x: [1]

--- a/reclass/values/tests/test_refitem.py
+++ b/reclass/values/tests/test_refitem.py
@@ -9,14 +9,17 @@ from reclass.values.listitem import ListItem
 from reclass.values.dictitem import DictItem
 from reclass.values.refitem import RefItem
 import unittest
-from mock import MagicMock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 
 SETTINGS = Settings()
 
 class TestRefItem(unittest.TestCase):
 
     def test_assembleRefs_ok(self):
-        phonyitem = MagicMock()
+        phonyitem = mock.MagicMock()
         phonyitem.render = lambda x, k: 'bar'
         phonyitem.has_references = True
         phonyitem.get_references = lambda *x: ['foo']
@@ -27,7 +30,7 @@ class TestRefItem(unittest.TestCase):
         self.assertTrue(iwr.allRefs)
 
     def test_assembleRefs_failedrefs(self):
-        phonyitem = MagicMock()
+        phonyitem = mock.MagicMock()
         phonyitem.render.side_effect = errors.ResolveError('foo')
         phonyitem.has_references = True
         phonyitem.get_references = lambda *x: ['foo']


### PR DESCRIPTION
This PR fixes running `python run_test.py` under python 3.x when the `python3-mock` package is not installed systemwide.

This PR should fix #97 
