### PR TITLE
Do not require enum34 with Python 3.4 and above

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyparsing
 pyyaml
 six
-enum34
+enum34 ; python_version<'3.4'
 ddt

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,10 @@ setup(
     url = URL,
     packages = find_packages(exclude=['*tests']), #FIXME validate this
     entry_points = { 'console_scripts': console_scripts },
-    install_requires = ['pyparsing', 'pyyaml', 'six', 'enum34', 'ddt'], #FIXME pygit2 (require libffi-dev, libgit2-dev 0.26.x )
+    install_requires = ['pyparsing', 'pyyaml', 'six', 'ddt'], #FIXME pygit2 (require libffi-dev, libgit2-dev 0.26.x )
+    extras_require = {
+        ":python_version<'3.4'": ['enum34'],
+    },
 
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
enum34 is a backport of the enum library of Python 3.4 to earlier Python
versions, so enum34 is not required for Python 3.4 and above and should
not be installed.

This will fix: #86