### PR TITLE
Add support for collections.abc in Python >=3.8

### DIFF
--- a/reclass/values/parser_funcs.py
+++ b/reclass/values/parser_funcs.py
@@ -14,6 +14,11 @@ import functools
 import pyparsing as pp
 import six
 
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
+
 tags = enum.Enum('Tags', ['STR', 'REF', 'INV'])
 
 _OBJ = 'OBJ'
@@ -49,7 +54,7 @@ def _asList(x):
     return x
 
 def listify(w, modifier=_asList):
-    if (isinstance(w, collections.Iterable) and
+    if (isinstance(w, collectionsAbc.Iterable) and
             not isinstance(w, six.string_types)):
         cls = type(w)
         if cls == pp.ParseResults:


### PR DESCRIPTION
Fixes the following error with Python >=3.8:
```
[...]
python ./run_tests.py
................................................EEEEEEEEEEEE.EEEEEE.EEEE...........E...EE.EEEEEEEEEEEEEE.EEEEE..EE.............EE........EEEEEEE..EEE...........E....EE........................EE.EEE...EE......EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE.......E.EE.EEEEEEEEE
======================================================================
ERROR: test_exports_failed_render (datatypes.tests.test_entity.TestEntityNoMock)                                                                              
----------------------------------------------------------------------                                                                                        
Traceback (most recent call last):                                                                                                                            
  File "/var/tmp/portage/dev-python/reclass-1.7.0/work/reclass-1.7.0/reclass/datatypes/tests/test_entity.py", line 291, in test_exports_failed_render         
    node1_exports = Exports({'a': '${a}'}, SETTINGS, '')                                                                                                      
  File "/var/tmp/portage/dev-python/reclass-1.7.0/work/reclass-1.7.0/reclass/datatypes/exports.py", line 24, in __init__                                      
    super(Exports, self).__init__(mapping, settings, uri)                                                                                                     
  File "/var/tmp/portage/dev-python/reclass-1.7.0/work/reclass-1.7.0/reclass/datatypes/parameters.py", line 67, in __init__                                   
    self.merge(mapping)                                                                                                                                       
  File "/var/tmp/portage/dev-python/reclass-1.7.0/work/reclass-1.7.0/reclass/datatypes/parameters.py", line 234, in merge                                     
    wrapped = self._wrap_dict(other)                                                                                                                          
  File "/var/tmp/portage/dev-python/reclass-1.7.0/work/reclass-1.7.0/reclass/datatypes/parameters.py", line 124, in _wrap_dict                                
    d[k] = self._get_wrapped(k, v)                                                                                                                            
  File "/var/tmp/portage/dev-python/reclass-1.7.0/work/reclass-1.7.0/reclass/datatypes/parameters.py", line 110, in _get_wrapped                              
    return self._wrap_value(value)                                                                                                                            
  File "/var/tmp/portage/dev-python/reclass-1.7.0/work/reclass-1.7.0/reclass/datatypes/parameters.py", line 102, in _wrap_value                                                                                                                                                                                               
    return Value(value, self._settings, self._uri,                                                                                                            
  File "/var/tmp/portage/dev-python/reclass-1.7.0/work/reclass-1.7.0/reclass/values/value.py", line 31, in __init__                                           
    self._item = self._parser.parse(value, self._settings)                                                                                                    
  File "/var/tmp/portage/dev-python/reclass-1.7.0/work/reclass-1.7.0/reclass/values/parser.py", line 68, in parse                                             
    tokens = parsers.listify(tokens)                                                                                                                          
  File "/var/tmp/portage/dev-python/reclass-1.7.0/work/reclass-1.7.0/reclass/values/parser_funcs.py", line 52, in listify                                     
    if (isinstance(w, collections.Iterable) and                                                                                                               
AttributeError: module 'collections' has no attribute 'Iterable'
[...]
```