### PR TITLE
Replace distutils.version with packaging.version

### DIFF
--- a/reclass/storage/yaml_git/__init__.py
+++ b/reclass/storage/yaml_git/__init__.py
@@ -8,11 +8,15 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import collections
-import distutils.version
 import errno
 import fcntl
 import os
 import time
+
+try:
+    from distutils.version import LooseVersion as Version
+except ModuleNotFoundError:
+    from packaging.version import Version
 
 # Squelch warning on centos7 due to upgrading cffi
 # see https://github.com/saltstack/salt/pull/39871
@@ -146,7 +150,7 @@ class GitRepo(object):
                 creds = pygit2.KeypairFromAgent(user)
 
             pygit2_version = pygit2.__version__
-            if distutils.version.LooseVersion(pygit2_version) >= distutils.version.LooseVersion('0.23.2'):
+            if Version(pygit2_version) >= Version('0.23.2'):
                 self.remotecallbacks = pygit2.RemoteCallbacks(credentials=creds)
                 self.credentials = None
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml
 six
 enum34 ; python_version<'3.4'
 ddt
+packaging ; python_version>'3.12'

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires = ['pyparsing', 'pyyaml', 'six', 'ddt'], #FIXME pygit2 (require libffi-dev, libgit2-dev 0.26.x )
     extras_require = {
         ":python_version<'3.4'": ['enum34'],
+        ":python_version>'3.12'": ['packaging'],
     },
 
     classifiers=[


### PR DESCRIPTION
distutils was removed in Python 3.12. It was only used to compare the pygit2 version. This replaces it with Version from packaging.